### PR TITLE
[Feature-JoinClub] Save Selected Team Unique Number In Datastore

### DIFF
--- a/app/src/main/java/com/example/footballmanager_pj/FootBallManagerAppNavigator.kt
+++ b/app/src/main/java/com/example/footballmanager_pj/FootBallManagerAppNavigator.kt
@@ -13,6 +13,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.example.feature_clubpage.presentation.screen.ClubPageScreen
 import com.example.feature_join.presentation.screen.JoinScreen
 import com.example.feature_join.presentation.screen.JoinSuccessScreen1
 import com.example.feature_join.presentation.screen.ProfileSettingScreen
@@ -64,6 +65,10 @@ fun FootBallManagerAppNavigator(
                 navHostController,
                 onNavigateToStudentVertificationScreen = {
                     navHostController.navigate("STUDENT_VERIFICATION") })
+        }
+        composable(Route.CLUB_PAGE) {
+            onNavigate(Route.CLUB_PAGE)
+            ClubPageScreen()
         }
         composable(Route.STUDENT_VERIFICATION) {
             onNavigate(Route.STUDENT_VERIFICATION)
@@ -171,7 +176,13 @@ fun FootBallManagerAppNavigator(
                 getJoinedClub = {
                     clubSearchViewModel.getJoinedClubList()
                 },
-                joinedTeamList = clubSearchViewModel.joinedClub.collectAsState()
+                joinedTeamList = clubSearchViewModel.joinedClub.collectAsState(),
+                onNavigateToClubPage = {
+                    navHostController.navigate("CLUB_PAGE")
+                },
+                saveUniqueNum = {
+                    clubSearchViewModel.saveSelectedTeamUniqueNum(it)
+                }
             )
         }
         composable(Route.CLUB_SEARCH) {

--- a/core/src/main/java/com/example/core/datasource/ClubDataSourceImpl.kt
+++ b/core/src/main/java/com/example/core/datasource/ClubDataSourceImpl.kt
@@ -27,7 +27,6 @@ class ClubDataSourceImpl @Inject constructor(
         )
         return when (result) {
             is RespResult.Success -> {
-                userLocalDataSource.saveUniqueNumber(result.data.unique.uniqueNumber)
                 MakeClubResult.Success(result.data.unique.uniqueNumber)
             }
 

--- a/core/src/main/java/com/example/core/datasource/UserLocalDataSource.kt
+++ b/core/src/main/java/com/example/core/datasource/UserLocalDataSource.kt
@@ -5,11 +5,12 @@ interface UserLocalDataSource {
     suspend fun saveAccount(account: String)
     suspend fun savePassword(password: String)
     suspend fun saveRefreshToken(refreshToken: String)
-    suspend fun saveUniqueNumber(uniqueNumber: String)
+    suspend fun saveSelectedTeamUniqueNumber(uniqueNumber: String)
     suspend fun saveUserId(userId: Long)
     suspend fun login()
     suspend fun join()
     suspend fun getAccessToken(): String
     suspend fun clearDataStore()
     suspend fun getUserId(): Long
+    suspend fun getSelectedTeamUniqueNumber(): String
 }

--- a/core/src/main/java/com/example/core/datasource/UserLocalDataSourceImpl.kt
+++ b/core/src/main/java/com/example/core/datasource/UserLocalDataSourceImpl.kt
@@ -35,7 +35,7 @@ internal class UserLocalDataSourceImpl @Inject constructor(
         }
     }
 
-    override suspend fun saveUniqueNumber(uniqueNumber: String) {
+    override suspend fun saveSelectedTeamUniqueNumber(uniqueNumber: String) {
         dataStore.edit {
             it[PreferenceKeys.UNIQUE_NUMBER] = uniqueNumber
         }
@@ -66,5 +66,9 @@ internal class UserLocalDataSourceImpl @Inject constructor(
 
     override suspend fun getUserId(): Long {
         return dataStore.data.first()[PreferenceKeys.USER_ID] ?: 0
+    }
+
+    override suspend fun getSelectedTeamUniqueNumber(): String {
+        return dataStore.data.first()[PreferenceKeys.UNIQUE_NUMBER] ?: ""
     }
 }

--- a/features/feature-joinclub/src/main/java/com/example/feature_joinclub/domain/usecase/GetSelectedTeamUniqueNumUseCase.kt
+++ b/features/feature-joinclub/src/main/java/com/example/feature_joinclub/domain/usecase/GetSelectedTeamUniqueNumUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.feature_joinclub.domain.usecase
+
+import com.example.core.datasource.UserLocalDataSource
+import javax.inject.Inject
+
+class GetSelectedTeamUniqueNumUseCase @Inject constructor(
+    private val userLocalDataSource: UserLocalDataSource
+) {
+    suspend operator fun invoke() : String{
+        return userLocalDataSource.getSelectedTeamUniqueNumber()
+    }
+}

--- a/features/feature-joinclub/src/main/java/com/example/feature_joinclub/domain/usecase/SaveSelectedTeamUniqueNumUseCase.kt
+++ b/features/feature-joinclub/src/main/java/com/example/feature_joinclub/domain/usecase/SaveSelectedTeamUniqueNumUseCase.kt
@@ -1,0 +1,12 @@
+package com.example.feature_joinclub.domain.usecase
+
+import com.example.core.datasource.UserLocalDataSource
+import javax.inject.Inject
+
+class SaveSelectedTeamUniqueNumUseCase @Inject constructor(
+    private val userLocalDataSource: UserLocalDataSource
+) {
+    suspend operator fun invoke(uniqueNum: String) {
+        userLocalDataSource.saveSelectedTeamUniqueNumber(uniqueNum)
+    }
+}

--- a/features/feature-joinclub/src/main/java/com/example/feature_joinclub/presentation/screen/JoinClubScreen.kt
+++ b/features/feature-joinclub/src/main/java/com/example/feature_joinclub/presentation/screen/JoinClubScreen.kt
@@ -36,6 +36,8 @@ fun JoinClubScreen(
     onNavigateToClubSearch: () -> Unit,
     getJoinedClub: () -> Unit,
     joinedTeamList: State<List<UserTeamInfoModel>>,
+    onNavigateToClubPage: () -> Unit,
+    saveUniqueNum: (String) -> Unit,
 ) {
     val showSheet = remember {
         mutableStateOf(true)
@@ -44,7 +46,10 @@ fun JoinClubScreen(
         getJoinedClub()
     }
     if (showSheet.value) {
-        DefaultBottomSheet(onDismiss = { showSheet.value = false }, containerColor = bottomSheetColor) {
+        DefaultBottomSheet(
+            onDismiss = { showSheet.value = false },
+            containerColor = bottomSheetColor
+        ) {
             val selectedIndex = remember {
                 mutableStateOf(-1)
             }
@@ -62,7 +67,13 @@ fun JoinClubScreen(
                     itemsIndexed(
                         joinedTeamList.value,
                         key = { _, item -> item.unique_num }) { index, club ->
-                        ClubItem(selectedIndex, index, {}) { JoinedClubContent(club = club) }
+                        ClubItem(selectedIndex, index, {}) {
+                            JoinedClubContent(
+                                club = club,
+                                onNavigateToClubPage,
+                                saveUniqueNum
+                            )
+                        }
                     }
                 }
             )
@@ -112,6 +123,8 @@ fun JoinClubScreenPreview() {
         onNavigateToMakeClub = {},
         onNavigateToClubSearch = {},
         getJoinedClub = {},
-        joinedTeamList = remember { mutableStateOf(dummyData) }
+        joinedTeamList = remember { mutableStateOf(dummyData) },
+        onNavigateToClubPage = {},
+        saveUniqueNum = {},
     )
 }

--- a/features/feature-joinclub/src/main/java/com/example/feature_joinclub/presentation/ui_component/ClubItem.kt
+++ b/features/feature-joinclub/src/main/java/com/example/feature_joinclub/presentation/ui_component/ClubItem.kt
@@ -1,6 +1,7 @@
 package com.example.feature_joinclub.presentation.ui_component
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -58,8 +59,7 @@ fun ClubItem(
 
                     if (selectedIndex.value == index) {
                         selectedIndex.value = -1
-                    }
-                    else {
+                    } else {
                         selectedIndex.value = index
                         on()
                     }
@@ -128,11 +128,19 @@ fun ClubContent(club: ClubInfo) {
 }
 
 @Composable
-fun JoinedClubContent(club: UserTeamInfoModel) {
+fun JoinedClubContent(
+    club: UserTeamInfoModel,
+    onNavigateToClubPage: () -> Unit,
+    saveUniqueNum: (String) -> Unit,
+) {
     Row(
         Modifier
             .padding(20.dp)
-            .fillMaxSize(),
+            .fillMaxSize()
+            .clickable {
+                saveUniqueNum(club.unique_num)
+                onNavigateToClubPage()
+            },
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Column(Modifier) {
@@ -180,6 +188,6 @@ fun ClubItemPreview() {
     ClubItem(selectedIndex = selectedIndex, index = 1, {}) {
         ClubContent(club = ClubInfo(3, "teamname", 20, "unique", "", ""))
     }
-    
+
 
 }

--- a/features/feature-joinclub/src/main/java/com/example/feature_joinclub/presentation/viewmodel/ClubSearchViewModel.kt
+++ b/features/feature-joinclub/src/main/java/com/example/feature_joinclub/presentation/viewmodel/ClubSearchViewModel.kt
@@ -9,6 +9,7 @@ import com.example.core.model.UserTeamInfoModel
 import com.example.coroutine.IoDispatcher
 import com.example.feature_joinclub.domain.usecase.ClubJoinRequestUseCase
 import com.example.feature_joinclub.domain.usecase.GetJoinedClubUseCase
+import com.example.feature_joinclub.domain.usecase.SaveSelectedTeamUniqueNumUseCase
 import com.example.feature_joinclub.domain.usecase.SearchClubUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -25,6 +26,7 @@ class ClubSearchViewModel @Inject constructor(
     private val searchClubUseCase: SearchClubUseCase,
     private val clubJoinRequestUseCase: ClubJoinRequestUseCase,
     private val getJoinedClubUseCase: GetJoinedClubUseCase,
+    private val saveSelectedTeamUniqueNumUseCase: SaveSelectedTeamUniqueNumUseCase,
     @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ): ViewModel(){
     private val _searchValue = MutableStateFlow("")
@@ -44,6 +46,10 @@ class ClubSearchViewModel @Inject constructor(
 
     private val _joinedClub = MutableStateFlow<List<UserTeamInfoModel>>(listOf())
     val joinedClub : StateFlow<List<UserTeamInfoModel>> = _joinedClub
+
+    init {
+        getJoinedClubList()
+    }
 
     fun searchClub(clubName: String) {
         _searchValue.value = clubName
@@ -72,4 +78,9 @@ class ClubSearchViewModel @Inject constructor(
         }
     }
 
+    fun saveSelectedTeamUniqueNum(uniqueNum: String) {
+        viewModelScope.launch {
+            saveSelectedTeamUniqueNumUseCase(uniqueNum)
+        }
+    }
 }


### PR DESCRIPTION
*  가입된 구단 목록 나타내는 bottom sheet에서 특정 구단 클릭 시 구단페이지로 이동
*  선택된 구단 uniqueNum datastore에 저장했습니다.
*  UserLocalDatasSource에서 getSelectedTeamUniqueNumber() 호출하셔서 사용하시면 됩니다.
*  uniqueNum 이외 구단 별  정보도 따로 저장 예정입니다.
